### PR TITLE
feat: Implement collapsible sidebars and auto-collapse

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
     <button id="createNewFileBtn" style="margin-top: 15px;" disabled>Create New Entry (Root)</button>
     <button id="createNewFolderBtn" style="margin-top: 10px;" disabled>Create New Folder (Root)</button>
     <button id="reorganizeEntriesBtn" style="margin-top: 10px;" disabled>Reorganize Entries</button>
+    <button id="collapseSidebarBtn" style="margin-top: 10px;">«</button>
 </aside>
 
       <div class="resizer" id="resizer"></div>
@@ -52,7 +53,7 @@
           <div class="main-content-wrapper">
 
               <aside class="image-preview-sidebar" id="imagePreviewSidebar" style="display: none;">
-                  <h2>Images</h2>
+                  <h2>Images</h2><button id="collapseImagePreviewBtn" style="margin-left: 10px;">»</button>
                   <div class="image-list-container" id="imageListContainer">
                       <!-- Images and delete buttons added dynamically -->
                   </div>

--- a/script.js
+++ b/script.js
@@ -5,6 +5,12 @@ document.addEventListener("DOMContentLoaded", async () => {
   const sidebar = document.getElementById("sidebar");
   const resizer = document.getElementById("resizer");
   const mainContent = document.getElementById("mainContent");
+  const containerDiv = document.querySelector(".container"); // Added
+  const collapseSidebarBtn = document.getElementById("collapseSidebarBtn"); // Added
+  const collapseImagePreviewBtn = document.getElementById("collapseImagePreviewBtn"); // Added
+  // imagePreviewSidebar is already defined further down, ensure it's used correctly.
+  // sidebar and resizer are defined above.
+
   const fileTreeRootUl = document.getElementById("fileTreeRoot");
   const jsonEntryContentDiv = document.getElementById("jsonEntryContent");
   const currentFileNameH2 = document.getElementById("currentFileName");
@@ -145,6 +151,45 @@ document.addEventListener("DOMContentLoaded", async () => {
     PROMPT_IMPROVE_CONTEXT_FOOTER,
     PROMPT_IMPROVE_MAIN_HEADER;
   const IMAGE_EXTENSIONS = [".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg"];
+
+  // --- Sidebar Collapse Functions ---
+  function toggleMainSidebar(collapse, isInitialLoad = false) {
+    if (!sidebar || !containerDiv || !resizer || !collapseSidebarBtn) {
+        console.error("Error: Main sidebar toggle components not found.");
+        return;
+    }
+    const actuallyCollapsing = typeof collapse === 'boolean' ? collapse : !sidebar.classList.contains("collapsed");
+
+    if (!isInitialLoad) console.log(`[SIDEBAR] Toggling main sidebar. Collapsing: ${actuallyCollapsing}`);
+
+    sidebar.classList.toggle("collapsed", actuallyCollapsing);
+    containerDiv.classList.toggle("sidebar-collapsed", actuallyCollapsing);
+    resizer.style.display = actuallyCollapsing ? "none" : "flex"; // 'flex' or 'block' depending on original display
+    localStorage.setItem("sidebarCollapsed", actuallyCollapsing ? "true" : "false");
+    collapseSidebarBtn.textContent = actuallyCollapsing ? "»" : "«";
+  }
+
+  function toggleImagePreviewSidebar(collapse, isInitialLoad = false) {
+    if (!imagePreviewSidebar || !collapseImagePreviewBtn) {
+        console.error("Error: Image preview sidebar toggle components not found.");
+        return;
+    }
+    // Ensure imagePreviewSidebar is defined (it's declared later in the original script)
+    // For safety, could re-get it here if there's doubt:
+    // const imagePreviewSidebar = document.getElementById("imagePreviewSidebar");
+    // const collapseImagePreviewBtn = document.getElementById("collapseImagePreviewBtn");
+
+    const actuallyCollapsing = typeof collapse === 'boolean' ? collapse : !imagePreviewSidebar.classList.contains("collapsed");
+
+    if (!isInitialLoad) console.log(`[SIDEBAR] Toggling image preview. Collapsing: ${actuallyCollapsing}`);
+    
+    imagePreviewSidebar.classList.toggle("collapsed", actuallyCollapsing);
+    // Optional: Add class to mainContentWrapper if specific styling needed beyond flex auto-adjust
+    // const mainContentWrapper = document.querySelector('.main-content-wrapper');
+    // if (mainContentWrapper) mainContentWrapper.classList.toggle("image-sidebar-collapsed", actuallyCollapsing);
+    localStorage.setItem("imagePreviewSidebarCollapsed", actuallyCollapsing ? "true" : "false");
+    collapseImagePreviewBtn.textContent = actuallyCollapsing ? "«" : "»";
+  }
 
   // --- CORE CONTROLS SETUP (API Modal, Clear Keys) ---
   function setupCoreControls() {
@@ -508,6 +553,19 @@ document.addEventListener("DOMContentLoaded", async () => {
     setupRenameEntryListener();
     setupReorganizeModalListeners();
 
+    // Add sidebar collapse button listeners
+    if (collapseSidebarBtn) {
+        collapseSidebarBtn.addEventListener("click", () => toggleMainSidebar());
+    } else {
+        console.warn("collapseSidebarBtn not found during setupAppEventListeners.");
+    }
+
+    if (collapseImagePreviewBtn) {
+        collapseImagePreviewBtn.addEventListener("click", () => toggleImagePreviewSidebar());
+    } else {
+        console.warn("collapseImagePreviewBtn not found during setupAppEventListeners.");
+    }
+
     console.log(
       "[SETUP_APP] Application-specific event listeners setup complete."
     );
@@ -615,9 +673,25 @@ document.addEventListener("DOMContentLoaded", async () => {
       repoNameSpan.textContent = `${GITHUB_USERNAME}/${GITHUB_REPO}`;
     if (repoPathSpan) repoPathSpan.textContent = `/${GITHUB_DATA_PATH}`;
 
- if (isReadOnlyLoad) {
-        setupAppEventListeners();
-        if (sidebar && resizer) makeResizable(sidebar, resizer);
+    // Setup listeners and resizer functionality before trying to load states
+    setupAppEventListeners();
+    if (sidebar && resizer) makeResizable(sidebar, resizer);
+
+    // Load sidebar states from localStorage
+    if (localStorage.getItem('sidebarCollapsed') === 'true') {
+        toggleMainSidebar(true, true); // true for collapse, true for initialLoad
+    }
+    if (localStorage.getItem('imagePreviewSidebarCollapsed') === 'true') {
+        toggleImagePreviewSidebar(true, true); // true for collapse, true for initialLoad
+    }
+    // Ensure button text is correct after initial load based on state
+    if (collapseSidebarBtn && sidebar) collapseSidebarBtn.textContent = sidebar.classList.contains("collapsed") ? "»" : "«";
+    if (collapseImagePreviewBtn && imagePreviewSidebar) collapseImagePreviewBtn.textContent = imagePreviewSidebar.classList.contains("collapsed") ? "«" : "»";
+
+
+    if (isReadOnlyLoad) {
+        // setupAppEventListeners(); // Moved up
+        // if (sidebar && resizer) makeResizable(sidebar, resizer); // Moved up
         console.log("[PROCEED_INIT] Fetching initial file list...");
         await fetchFileList(); // This populates flatJsonData
 
@@ -2187,6 +2261,12 @@ document.title = `${currentJsonData?.name || "Entry"} - Globeseekers`; // Update
         console.log(
           `[LOAD] Successfully fetched data for ${filePath} with SHA: ${currentFileSha}`
         );
+
+        // E. Automatic Main Sidebar Collapse on File Open
+        if (sidebar && !sidebar.classList.contains('collapsed')) {
+            console.log("[AUTO-COLLAPSE] File opened, collapsing main sidebar.");
+            toggleMainSidebar(true); // Explicitly collapse
+        }
 
         if (activeLinkElement && activeLinkElement !== linkElement) {
           activeLinkElement.classList.remove("active");

--- a/style.css
+++ b/style.css
@@ -1239,3 +1239,86 @@ img {
         max-height: 20vh;
     }
 }
+
+/* --- Collapse Button Styles --- */
+
+#collapseSidebarBtn {
+    display: block; 
+    width: calc(100% - 10px); 
+    margin: 10px 5px;
+    padding: 8px;
+    font-size: 1.2em; 
+    text-align: center;
+    background-color: #e0e0e0;
+    border: 1px solid #cccccc;
+    border-radius: 3px;
+    cursor: pointer;
+    order: 99; /* Place it at the bottom of flex container, assuming other buttons don't have higher order */
+    /* order: -1; was suggested for top, but previous button was added at the end of html, so bottom seems more natural with current html */
+}
+
+#collapseSidebarBtn:hover {
+    background-color: #d0d0d0;
+}
+
+.image-preview-sidebar h2 {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+#collapseImagePreviewBtn {
+    padding: 3px 8px;
+    font-size: 1.2em; 
+    background-color: #e0e0e0;
+    border: 1px solid #cccccc;
+    border-radius: 3px;
+    cursor: pointer;
+    margin-left: 10px; 
+}
+
+#collapseImagePreviewBtn:hover {
+    background-color: #d0d0d0;
+}
+
+/* --- Sidebar Collapsed State --- */
+
+.collapsed {
+    width: 0 !important; 
+    min-width: 0 !important; 
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+    border-left-width: 0 !important;
+    border-right-width: 0 !important;
+    box-shadow: none !important;
+    overflow: hidden !important; 
+    visibility: hidden !important; /* Changed from visibility: hidden to ensure it's fully hidden */
+    /* margin-left: 0 !important; /* Added to remove any margin when collapsed */
+    /* margin-right: 0 !important; /* Added to remove any margin when collapsed */
+}
+
+/* Adjustments when main sidebar is collapsed */
+.container.sidebar-collapsed .resizer {
+    display: none !important;
+}
+
+/* Alternative specific resizer hiding if not using global container class */
+/* #sidebar.collapsed + .resizer {
+    display: none !important;
+} */
+
+/*
+  No specific styles needed for .container.image-sidebar-collapsed or .main-content-wrapper.image-sidebar-collapsed
+  as the .collapsed class on #imagePreviewSidebar itself should handle its dimensions,
+  and flexbox should allow .entry-view-edit-area to expand.
+*/
+
+/* Ensure buttons inside collapsed sidebars are not focusable/visible if somehow not hidden by overflow */
+.sidebar.collapsed > button,
+.sidebar.collapsed > nav,
+.image-preview-sidebar.collapsed > button,
+.image-preview-sidebar.collapsed > div {
+    visibility: hidden !important;
+    opacity: 0 !important;
+    pointer-events: none !important;
+}


### PR DESCRIPTION
This commit introduces the following features:

1.  **Collapsible Main Sidebar:**
    *   You can now collapse and expand the main file tree sidebar using a toggle button.
    *   The collapsed state is persisted in localStorage.
    *   The resizer is hidden when the sidebar is collapsed.

2.  **Collapsible Image Preview Sidebar:**
    *   You can now collapse and expand the image preview sidebar using a toggle button.
    *   The collapsed state is persisted in localStorage.

3.  **Automatic Main Sidebar Collapse:**
    *   The main sidebar automatically collapses when you open/select a file from the file tree, improving focus on the content.

Modifications were made to index.html to add toggle buttons, style.css for styling the buttons and collapsed states, and script.js to implement the functionality, including localStorage persistence and dynamic class toggling.