### PR TITLE
Fix: Ensure sidebar toggle buttons are always visible and content hid…

### DIFF
--- a/style.css
+++ b/style.css
@@ -1306,7 +1306,7 @@ img {
     border-right-width: 0 !important;
     box-shadow: none !important;
     overflow: hidden !important; 
-    visibility: hidden !important; /* Changed from visibility: hidden to ensure it's fully hidden */
+    /* visibility: hidden !important; /* MODIFIED - REMOVED */
     /* margin-left: 0 !important; /* Added to remove any margin when collapsed */
     /* margin-right: 0 !important; /* Added to remove any margin when collapsed */
 }
@@ -1333,15 +1333,81 @@ img {
 /* (e.g., JavaScript not removing '.collapsed', or other CSS rules). */
 
 /* For the main sidebar (#sidebar, which has class .sidebar) */
-.sidebar.collapsed > button, /* Targets buttons like #collapseSidebarBtn, #createNewFileBtn etc. */
 .sidebar.collapsed > nav {   /* Targets nav like #fileTreeContainer */
     visibility: hidden !important;
     opacity: 0 !important;
     pointer-events: none !important;
 }
 
+#imagePreviewSidebar.collapsed {
+    width: 0 !important;
+    min-width: 0 !important;
+    visibility: visible !important; /* Allow positioned children to be visible */
+    overflow: visible !important; /* Allow positioned children to be visible */
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+    border-left-width: 0 !important;
+    border-right-width: 0 !important;
+    box-shadow: none !important;
+}
+
+#imagePreviewSidebar.collapsed > *:not(h2):not(#collapseImagePreviewBtn) { /* Hide all direct children except h2 and the button itself */
+    visibility: hidden !important;
+    opacity: 0 !important;
+    pointer-events: none !important;
+}
+
+/* Specifically ensure the h2 (which contains the button) and the button are visible */
+#imagePreviewSidebar.collapsed > h2,
+#imagePreviewSidebar.collapsed #collapseImagePreviewBtn {
+    visibility: visible !important;
+    opacity: 1 !important;
+    pointer-events: auto !important;
+}
+
+#imagePreviewSidebar.collapsed #collapseImagePreviewBtn {
+    position: fixed; /* Or absolute, depending on desired behavior relative to viewport or a parent */
+    top: 15px; /* Adjust as needed */
+    right: 10px; /* Adjust as needed, assuming it's on the right */
+    width: auto;
+    margin: 0;
+    padding: 8px 10px; /* Explicit padding */
+    z-index: 1050;
+}
+
+#sidebar.collapsed {
+    width: 0 !important;
+    min-width: 0 !important;
+    visibility: visible !important; /* Allow positioned children to be visible */
+    overflow: visible !important; /* Allow positioned children to be visible */
+    /* Inherit other .collapsed styles like padding, border, box-shadow as needed or reset them */
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+    border-left-width: 0 !important;
+    border-right-width: 0 !important;
+    box-shadow: none !important;
+}
+
+#sidebar.collapsed > *:not(#collapseSidebarBtn) {
+    visibility: hidden !important;
+    opacity: 0 !important;
+    pointer-events: none !important;
+}
+
+#sidebar.collapsed #collapseSidebarBtn {
+    visibility: visible !important;
+    opacity: 1 !important;
+    pointer-events: auto !important;
+    position: fixed;
+    top: 15px;
+    left: 10px;
+    width: auto; /* Override general button styling within sidebar */
+    margin: 0;
+    padding: 8px 10px; /* Explicit padding */
+    z-index: 1050;
+}
+
 /* For the image preview sidebar */
-.image-preview-sidebar.collapsed > button, /* Targets buttons like #addImageBtn */
 .image-preview-sidebar.collapsed > div {    /* Targets divs like #imageListContainer */
     visibility: hidden !important;
     opacity: 0 !important;


### PR DESCRIPTION
…es correctly

This addresses issues where sidebar toggle buttons would disappear when sidebars were collapsed and potential issues with content list visibility.

- I modified the CSS for the main sidebar (#sidebar) and its toggle button (#collapseSidebarBtn):
  - The #collapseSidebarBtn is now always visible and positioned fixed at the top-left when the sidebar is collapsed.
  - When collapsed, the #sidebar has zero width, but `visibility: visible` and `overflow: visible` to allow the fixed-position button to show.
  - Content within the collapsed #sidebar (e.g., file tree) is hidden.
  - I removed `visibility: hidden` from the general `.collapsed` class to support this.

- I modified the CSS for the image preview sidebar (#imagePreviewSidebar) and its toggle button (#collapseImagePreviewBtn):
  - The #collapseImagePreviewBtn (within its h2 parent) is now always visible and positioned fixed at the top-right when this sidebar is collapsed.
  - Similar to the main sidebar, #imagePreviewSidebar has zero width but appropriate visibility/overflow when collapsed.
  - Content within the collapsed #imagePreviewSidebar is hidden.

- I verified that the file tree in the main sidebar and content in the image preview sidebar display correctly when the sidebars are expanded.