### PR TITLE
Fix: Ensure main content sidebar starts expanded

### DIFF
--- a/script.js
+++ b/script.js
@@ -678,11 +678,13 @@ document.addEventListener("DOMContentLoaded", async () => {
     if (sidebar && resizer) makeResizable(sidebar, resizer);
 
     // Load sidebar states from localStorage
-    if (localStorage.getItem('sidebarCollapsed') === 'true') {
-        toggleMainSidebar(true, true); // true for collapse, true for initialLoad
-    }
+    // Force main sidebar to start expanded
+    toggleMainSidebar(false, true); // false for collapse (i.e., expand), true for initialLoad
+    localStorage.setItem("sidebarCollapsed", "false"); // Update localStorage to reflect this default
+
+    // Image preview sidebar can still respect localStorage
     if (localStorage.getItem('imagePreviewSidebarCollapsed') === 'true') {
-        toggleImagePreviewSidebar(true, true); // true for collapse, true for initialLoad
+        toggleImagePreviewSidebar(true, true);
     }
     // Ensure button text is correct after initial load based on state
     if (collapseSidebarBtn && sidebar) collapseSidebarBtn.textContent = sidebar.classList.contains("collapsed") ? "»" : "«";


### PR DESCRIPTION
I modified `script.js` to change the initial loading behavior of the main content sidebar. The sidebar will now default to an expanded state when the application is loaded, and this preference will be saved to localStorage.

Previously, if `localStorage` had 'sidebarCollapsed' set to 'true', the sidebar would start collapsed. This change ensures a consistent expanded view by default, addressing the issue where you might find the sidebar content not immediately visible.

The image preview sidebar's behavior remains unchanged and will continue to respect its stored collapsed state.