### PR TITLE
Fix: Correct sidebar content visibility and toggle responsiveness

### DIFF
--- a/script.js
+++ b/script.js
@@ -135,6 +135,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   let GEMINI_API_KEY = null; // From sessionStorage
 
   // --- Constants (populated from config) ---
+  const MOBILE_BREAKPOINT = 768; // Added
   let GITHUB_USERNAME,
     GITHUB_REPO,
     GITHUB_DATA_PATH,
@@ -155,18 +156,56 @@ document.addEventListener("DOMContentLoaded", async () => {
   // --- Sidebar Collapse Functions ---
   function toggleMainSidebar(collapse, isInitialLoad = false) {
     if (!sidebar || !containerDiv || !resizer || !collapseSidebarBtn) {
-        console.error("Error: Main sidebar toggle components not found.");
-        return;
+      console.error("Error: Main sidebar toggle components not found.");
+      return;
     }
-    const actuallyCollapsing = typeof collapse === 'boolean' ? collapse : !sidebar.classList.contains("collapsed");
 
-    if (!isInitialLoad) console.log(`[SIDEBAR] Toggling main sidebar. Collapsing: ${actuallyCollapsing}`);
+    const screenWidth = window.innerWidth;
 
-    sidebar.classList.toggle("collapsed", actuallyCollapsing);
-    containerDiv.classList.toggle("sidebar-collapsed", actuallyCollapsing);
-    resizer.style.display = actuallyCollapsing ? "none" : "flex"; // 'flex' or 'block' depending on original display
-    localStorage.setItem("sidebarCollapsed", actuallyCollapsing ? "true" : "false");
-    collapseSidebarBtn.textContent = actuallyCollapsing ? "»" : "«";
+    if (screenWidth <= MOBILE_BREAKPOINT) {
+      // Mobile behavior
+      let actuallyCollapsingMobile;
+      if (typeof collapse === 'boolean') {
+        actuallyCollapsingMobile = collapse;
+      } else {
+        actuallyCollapsingMobile = !sidebar.classList.contains("mobile-collapsed");
+      }
+
+      if (!isInitialLoad) console.log(`[SIDEBAR_MOBILE] Toggling main sidebar. Collapsing: ${actuallyCollapsingMobile}`);
+
+      sidebar.classList.toggle("mobile-collapsed", actuallyCollapsingMobile);
+      // Ensure desktop classes are removed on mobile
+      sidebar.classList.remove("collapsed");
+      containerDiv.classList.remove("sidebar-collapsed");
+      if (resizer) resizer.style.display = "none"; // Resizer typically hidden on mobile by CSS
+
+      localStorage.setItem("sidebarMobileCollapsed", actuallyCollapsingMobile ? "true" : "false");
+      // Clear desktop local storage if we are on mobile to avoid confusion on resize
+      // localStorage.removeItem("sidebarCollapsed");
+      collapseSidebarBtn.textContent = actuallyCollapsingMobile ? "☰" : "✕"; // Hamburger/Close icons
+
+    } else {
+      // Desktop behavior
+      let actuallyCollapsingDesktop;
+      if (typeof collapse === 'boolean') {
+        actuallyCollapsingDesktop = collapse;
+      } else {
+        actuallyCollapsingDesktop = !sidebar.classList.contains("collapsed");
+      }
+
+      if (!isInitialLoad) console.log(`[SIDEBAR_DESKTOP] Toggling main sidebar. Collapsing: ${actuallyCollapsingDesktop}`);
+
+      sidebar.classList.toggle("collapsed", actuallyCollapsingDesktop);
+      containerDiv.classList.toggle("sidebar-collapsed", actuallyCollapsingDesktop);
+      if (resizer) resizer.style.display = actuallyCollapsingDesktop ? "none" : "flex";
+
+      localStorage.setItem("sidebarCollapsed", actuallyCollapsingDesktop ? "true" : "false");
+      // Ensure mobile class is removed on desktop
+      sidebar.classList.remove("mobile-collapsed");
+      // Clear mobile local storage if we are on desktop
+      // localStorage.removeItem("sidebarMobileCollapsed");
+      collapseSidebarBtn.textContent = actuallyCollapsingDesktop ? "»" : "«"; // Arrows for desktop
+    }
   }
 
   function toggleImagePreviewSidebar(collapse, isInitialLoad = false) {
@@ -678,17 +717,29 @@ document.addEventListener("DOMContentLoaded", async () => {
     if (sidebar && resizer) makeResizable(sidebar, resizer);
 
     // Load sidebar states from localStorage
-    // Force main sidebar to start expanded
-    toggleMainSidebar(false, true); // false for collapse (i.e., expand), true for initialLoad
-    localStorage.setItem("sidebarCollapsed", "false"); // Update localStorage to reflect this default
+    const screenWidthInitial = window.innerWidth;
+    if (screenWidthInitial <= MOBILE_BREAKPOINT) {
+      const mobileCollapsed = localStorage.getItem("sidebarMobileCollapsed") === "true";
+      toggleMainSidebar(mobileCollapsed, true);
+      // Optional: Default to expanded on mobile initial load, regardless of storage
+      // toggleMainSidebar(false, true);
+      // localStorage.setItem("sidebarMobileCollapsed", "false");
+    } else {
+      const desktopCollapsed = localStorage.getItem("sidebarCollapsed") === "true";
+      // Default to expanded on desktop initial load if nothing is stored
+      // toggleMainSidebar(desktopCollapsed || false, true);
+      // Forcing expanded on initial desktop load for now, as per original logic for desktop:
+      toggleMainSidebar(false, true);
+      localStorage.setItem("sidebarCollapsed", "false");
+    }
 
     // Image preview sidebar can still respect localStorage
     if (localStorage.getItem('imagePreviewSidebarCollapsed') === 'true') {
         toggleImagePreviewSidebar(true, true);
     }
-    // Ensure button text is correct after initial load based on state
-    if (collapseSidebarBtn && sidebar) collapseSidebarBtn.textContent = sidebar.classList.contains("collapsed") ? "»" : "«";
-    if (collapseImagePreviewBtn && imagePreviewSidebar) collapseImagePreviewBtn.textContent = imagePreviewSidebar.classList.contains("collapsed") ? "«" : "»";
+    // Ensure button text is correct after initial load based on state - toggleMainSidebar now handles this.
+    // if (collapseSidebarBtn && sidebar) collapseSidebarBtn.textContent = sidebar.classList.contains("collapsed") ? "»" : "«";
+    // if (collapseImagePreviewBtn && imagePreviewSidebar) collapseImagePreviewBtn.textContent = imagePreviewSidebar.classList.contains("collapsed") ? "«" : "»";
 
 
     if (isReadOnlyLoad) {
@@ -2264,9 +2315,9 @@ document.title = `${currentJsonData?.name || "Entry"} - Globeseekers`; // Update
           `[LOAD] Successfully fetched data for ${filePath} with SHA: ${currentFileSha}`
         );
 
-        // E. Automatic Main Sidebar Collapse on File Open
-        if (sidebar && !sidebar.classList.contains('collapsed')) {
-            console.log("[AUTO-COLLAPSE] File opened, collapsing main sidebar.");
+        // E. Automatic Main Sidebar Collapse on File Open (Desktop only for this behavior)
+        if (window.innerWidth > MOBILE_BREAKPOINT && sidebar && !sidebar.classList.contains('collapsed') && !sidebar.classList.contains('mobile-collapsed')) {
+            console.log("[AUTO-COLLAPSE] File opened on desktop, collapsing main sidebar.");
             toggleMainSidebar(true); // Explicitly collapse
         }
 
@@ -4201,7 +4252,17 @@ document.title = `${currentJsonData?.name || "Entry"} - Globeseekers`; // Update
     let isResizing = false;
     let startX, startWidth;
     if (!element || !resizerElement) return;
+
+    // Disable resizer on mobile explicitly if not already handled by CSS
+    if (window.innerWidth <= MOBILE_BREAKPOINT) {
+        if(resizerElement) resizerElement.style.display = 'none';
+        return;
+    } else {
+        if(resizerElement) resizerElement.style.display = 'flex'; // Or original display type
+    }
+
     resizerElement.addEventListener("mousedown", (e) => {
+      if (window.innerWidth <= MOBILE_BREAKPOINT) return; // Extra check
       isResizing = true;
       startX = e.clientX;
       startWidth = parseInt(window.getComputedStyle(element).width, 10);
@@ -4215,7 +4276,7 @@ document.title = `${currentJsonData?.name || "Entry"} - Globeseekers`; // Update
       const deltaX = e.clientX - startX;
       let newWidth = startWidth + deltaX;
       const minW = 200;
-      const maxW = window.innerWidth - 150;
+      const maxW = window.innerWidth - 150; // Ensure main content has some space
       newWidth = Math.max(minW, Math.min(newWidth, maxW));
       element.style.width = `${newWidth}px`;
     }
@@ -4229,6 +4290,34 @@ document.title = `${currentJsonData?.name || "Entry"} - Globeseekers`; // Update
       }
     }
   }
+
+  // --- Resize Handler for Sidebar State ---
+  function handleResizeForSidebarState() {
+    if (!sidebar || !containerDiv || !resizer || !collapseSidebarBtn) return;
+
+    const screenWidth = window.innerWidth;
+    const isCurrentlyMobile = sidebar.classList.contains("mobile-collapsed") || (localStorage.getItem("sidebarMobileCollapsed") === "true" && screenWidth <= MOBILE_BREAKPOINT);
+    const isCurrentlyDesktopCollapsed = sidebar.classList.contains("collapsed");
+
+    // Call toggleMainSidebar with null to make it re-evaluate based on current classes and new width
+    // The `true` for isInitialLoad prevents console logs and ensures it behaves like a state refresh.
+    toggleMainSidebar(null, true);
+
+    // Additional logic for resizer visibility if not covered by toggleMainSidebar
+    if (screenWidth <= MOBILE_BREAKPOINT) {
+        if (resizer) resizer.style.display = 'none';
+    } else {
+        // If switching to desktop, and sidebar is not collapsed, show resizer.
+        // toggleMainSidebar should handle this, but as a fallback:
+        if (resizer && !sidebar.classList.contains("collapsed")) {
+            resizer.style.display = 'flex'; // Or original display type
+        } else if (resizer && sidebar.classList.contains("collapsed")) {
+            resizer.style.display = 'none';
+        }
+    }
+  }
+  window.addEventListener('resize', handleResizeForSidebarState);
+
 
   function setupCreateNewFolderListener() {
     if (createNewFolderBtn) {

--- a/style.css
+++ b/style.css
@@ -1185,11 +1185,42 @@ img {
 
     /* Collapse Button Adjustments for Tablet/Mobile */
     #collapseSidebarBtn {
-        padding: 12px; /* Increased padding for touch */
-        font-size: 1.4em; /* Slightly larger icon */
-        /* width: 100%; Ensure it spans well if margin was an issue, but calc(100% - 10px) should be fine */
-        /* margin: 10px 0; Center it if full width */
+        padding: 10px; /* Adjusted padding for touch */
+        font-size: 1.3em; /* Slightly larger icon */
+        width: 100%; /* Make it full width for easier tapping */
+        margin: 5px 0; /* Adjust margin for full width */
+        box-sizing: border-box; /* Include padding in width */
+        line-height: 1.5; /* Ensure text (☰ or ✕) is vertically centered */
+        display: flex; /* Use flex to center content */
+        align-items: center;
+        justify-content: center;
     }
+
+    /* Styles for the main sidebar when it's mobile-collapsed */
+    .sidebar.mobile-collapsed {
+        max-height: 50px !important; /* Adjust to fit button, e.g., 40px padding + 10px text = 50px */
+        padding-top: 0 !important;
+        padding-bottom: 0 !important;
+        border-top-width: 0 !important;
+        border-bottom-width: 0 !important; /* Keep bottom border for separation */
+        border-bottom: 2px solid #bbbbbb !important; /* Re-ensure this border */
+        overflow: hidden !important;
+        box-shadow: none !important;
+    }
+
+    .sidebar.mobile-collapsed > *:not(#collapseSidebarBtn) {
+        display: none !important;
+    }
+
+    /* Ensure the button inside mobile-collapsed sidebar is correctly styled */
+    .sidebar.mobile-collapsed #collapseSidebarBtn {
+        margin: 5px 0; /* Consistent margin */
+        width: 100%; /* Takes full width of the parent (which is now full screen width) */
+        /* Padding and font-size are inherited from the general #collapseSidebarBtn mobile style */
+        /* No need for fixed positioning here */
+        position: static !important; /* Override any fixed positioning from desktop rules */
+    }
+
 
     #collapseImagePreviewBtn {
         padding: 10px 12px; /* Increased padding for touch */
@@ -1298,17 +1329,16 @@ img {
 /* --- Sidebar Collapsed State --- */
 
 .collapsed {
-    width: 0 !important; 
-    min-width: 0 !important; 
+    width: 0 !important;
+    min-width: 0 !important;
     padding-left: 0 !important;
     padding-right: 0 !important;
     border-left-width: 0 !important;
     border-right-width: 0 !important;
     box-shadow: none !important;
-    overflow: hidden !important; 
-    /* visibility: hidden !important; /* MODIFIED - REMOVED */
-    /* margin-left: 0 !important; /* Added to remove any margin when collapsed */
-    /* margin-right: 0 !important; /* Added to remove any margin when collapsed */
+    overflow: hidden !important;
+    /* Ensure no visibility override that would make it visible when it shouldn't be */
+    /* visibility: hidden; /* This would hide it, but overflow:hidden on parent is preferred */
 }
 
 /* Adjustments when main sidebar is collapsed */
@@ -1333,17 +1363,63 @@ img {
 /* (e.g., JavaScript not removing '.collapsed', or other CSS rules). */
 
 /* For the main sidebar (#sidebar, which has class .sidebar) */
-.sidebar.collapsed > nav {   /* Targets nav like #fileTreeContainer */
-    visibility: hidden !important;
-    opacity: 0 !important;
-    pointer-events: none !important;
+/* Children of a collapsed sidebar should be hidden by the parent's overflow: hidden and zero dimensions. */
+/* Remove explicit visibility/opacity rules on children like nav. */
+.sidebar.collapsed > nav {
+    /* visibility: hidden !important; /* REMOVED */
+    /* opacity: 0 !important; /* REMOVED */
+    /* pointer-events: none !important; /* REMOVED */
 }
 
+/* Specific styles for #sidebar.collapsed */
+/* This rule ensures that when #sidebar specifically is collapsed, */
+/* it correctly applies the zero-dimension and overflow properties. */
+/* It overrides any broader .sidebar styles that might conflict. */
+#sidebar.collapsed {
+    width: 0 !important;
+    min-width: 0 !important;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+    border-left-width: 0 !important;
+    border-right-width: 0 !important;
+    box-shadow: none !important; /* Already in .collapsed but good to be explicit */
+    overflow: hidden !important; /* CRITICAL: This hides children */
+    /* visibility: hidden !important; /* AVOID: Use overflow and zero dimensions instead */
+}
+
+/* Remove rules that hide children of #sidebar.collapsed using visibility/opacity */
+#sidebar.collapsed > *:not(#collapseSidebarBtn) {
+    /* visibility: hidden !important; /* REMOVED */
+    /* opacity: 0 !important; /* REMOVED */
+    /* pointer-events: none !important; /* REMOVED */
+}
+
+/* Ensure the collapse button itself remains visible and interactive */
+/* This rule for #collapseSidebarBtn needs to be outside of #sidebar.collapsed > * if it's to override it,
+   or be more specific. The current fixed positioning might be okay.
+   The existing #sidebar.collapsed #collapseSidebarBtn rule handles this.
+*/
+#sidebar.collapsed #collapseSidebarBtn {
+    visibility: visible !important; /* Ensure button is visible */
+    opacity: 1 !important; /* Ensure button is fully opaque */
+    pointer-events: auto !important; /* Ensure button is interactive */
+    position: fixed; /* Keep fixed positioning */
+    top: 15px;
+    left: 10px;
+    width: auto;
+    margin: 0;
+    padding: 8px 10px;
+    z-index: 1050; /* Ensure it's above other elements */
+}
+
+
+/* Styles for #imagePreviewSidebar.collapsed (leaving as is for now, focusing on #sidebar first) */
 #imagePreviewSidebar.collapsed {
     width: 0 !important;
     min-width: 0 !important;
-    visibility: visible !important; /* Allow positioned children to be visible */
-    overflow: visible !important; /* Allow positioned children to be visible */
+    /* visibility: visible !important; /* REMOVED */
+    /* overflow: visible !important; /* REMOVED */
+    overflow: hidden !important; /* ADDED */
     padding-left: 0 !important;
     padding-right: 0 !important;
     border-left-width: 0 !important;
@@ -1351,13 +1427,15 @@ img {
     box-shadow: none !important;
 }
 
-#imagePreviewSidebar.collapsed > *:not(h2):not(#collapseImagePreviewBtn) { /* Hide all direct children except h2 and the button itself */
+/* This rule is no longer needed as parent's overflow:hidden should hide children. */
+/*
+#imagePreviewSidebar.collapsed > *:not(h2):not(#collapseImagePreviewBtn) {
     visibility: hidden !important;
     opacity: 0 !important;
     pointer-events: none !important;
 }
+*/
 
-/* Specifically ensure the h2 (which contains the button) and the button are visible */
 #imagePreviewSidebar.collapsed > h2,
 #imagePreviewSidebar.collapsed #collapseImagePreviewBtn {
     visibility: visible !important;
@@ -1366,50 +1444,21 @@ img {
 }
 
 #imagePreviewSidebar.collapsed #collapseImagePreviewBtn {
-    position: fixed; /* Or absolute, depending on desired behavior relative to viewport or a parent */
-    top: 15px; /* Adjust as needed */
-    right: 10px; /* Adjust as needed, assuming it's on the right */
-    width: auto;
-    margin: 0;
-    padding: 8px 10px; /* Explicit padding */
-    z-index: 1050;
-}
-
-#sidebar.collapsed {
-    width: 0 !important;
-    min-width: 0 !important;
-    visibility: visible !important; /* Allow positioned children to be visible */
-    overflow: visible !important; /* Allow positioned children to be visible */
-    /* Inherit other .collapsed styles like padding, border, box-shadow as needed or reset them */
-    padding-left: 0 !important;
-    padding-right: 0 !important;
-    border-left-width: 0 !important;
-    border-right-width: 0 !important;
-    box-shadow: none !important;
-}
-
-#sidebar.collapsed > *:not(#collapseSidebarBtn) {
-    visibility: hidden !important;
-    opacity: 0 !important;
-    pointer-events: none !important;
-}
-
-#sidebar.collapsed #collapseSidebarBtn {
-    visibility: visible !important;
-    opacity: 1 !important;
-    pointer-events: auto !important;
     position: fixed;
     top: 15px;
-    left: 10px;
-    width: auto; /* Override general button styling within sidebar */
+    right: 10px;
+    width: auto;
     margin: 0;
-    padding: 8px 10px; /* Explicit padding */
+    padding: 8px 10px;
     z-index: 1050;
 }
 
-/* For the image preview sidebar */
-.image-preview-sidebar.collapsed > div {    /* Targets divs like #imageListContainer */
+/* For the image preview sidebar's children (leaving as is) */
+/* This rule is also redundant if parent's overflow:hidden is effective. */
+/*
+.image-preview-sidebar.collapsed > div {
     visibility: hidden !important;
     opacity: 0 !important;
     pointer-events: none !important;
 }
+*/


### PR DESCRIPTION
This commit addresses issues with the left sidebar's content list not being visible and adjusts the toggle mechanism to work correctly across all screen sizes.

Key changes:

- Desktop Sidebar Collapse:
  - Simplified CSS for `.collapsed` and `#sidebar.collapsed`.
  - Removed contradictory `visibility: visible !important` and `overflow: visible !important` from `#sidebar.collapsed`.
  - Relies on `overflow: hidden` and zero dimensions on the collapsed sidebar to hide content, rather than individually hiding child elements.
  - Ensured the collapse button (`#collapseSidebarBtn`) remains visible and functional with `position: fixed` when the sidebar is collapsed on desktop.

- Mobile Sidebar Collapse:
  - Implemented a mobile-specific collapse behavior for the main sidebar (`#sidebar`).
  - JavaScript's `toggleMainSidebar()` now checks screen width.
  - On mobile (<= 768px), it toggles a `.mobile-collapsed` class.
  - CSS for `.sidebar.mobile-collapsed` hides sidebar contents and reduces its `max-height` to accommodate only the toggle button.
  - The toggle button (`#collapseSidebarBtn`) icon changes to "☰" (collapsed) / "✕" (expanded) on mobile.
  - A window resize listener ensures the correct collapse mode (desktop/mobile) and button icons are applied when switching between viewport sizes.

- Image Preview Sidebar:
  - Applied similar CSS cleanup to `#imagePreviewSidebar.collapsed` for consistent content hiding on desktop.
  - Verified its JavaScript toggle logic.

These changes ensure the sidebar content is correctly displayed or hidden based on its state and the screen size, and that the toggle buttons are reliable and provide appropriate visual feedback.