### PR TITLE
Fix: Improve scrolling for file tree in sidebar

### DIFF
--- a/style.css
+++ b/style.css
@@ -348,6 +348,8 @@ img {
 #fileTreeContainer {
   flex-grow: 1;
   margin-top: 10px;
+  overflow-y: auto;
+  min-height: 0;
 }
 
 #fileTreeRoot {


### PR DESCRIPTION
Added `overflow-y: auto;` and `min-height: 0;` to the `#fileTreeContainer` CSS rule.

This ensures that if the file tree's content exceeds the available vertical space within the sidebar, the tree container itself will become scrollable. The `min-height: 0` property is important in flexbox layouts to allow scrollable children to correctly calculate their size and enable overflow scrolling when `flex-grow` is also used.

This addresses the issue where the full list of articles in the tree might not be visible due to lack of scrolling.