### PR TITLE
Refactor: Use distinct class names for sidebar and tree node collapse

### DIFF
--- a/script.js
+++ b/script.js
@@ -175,8 +175,8 @@ document.addEventListener("DOMContentLoaded", async () => {
 
       sidebar.classList.toggle("mobile-collapsed", actuallyCollapsingMobile);
       // Ensure desktop classes are removed on mobile
-      sidebar.classList.remove("collapsed");
-      containerDiv.classList.remove("sidebar-collapsed");
+      sidebar.classList.remove("sidebar-is-collapsed");
+      containerDiv.classList.remove("sidebar-is-collapsed");
       if (resizer) resizer.style.display = "none"; // Resizer typically hidden on mobile by CSS
 
       localStorage.setItem("sidebarMobileCollapsed", actuallyCollapsingMobile ? "true" : "false");
@@ -190,13 +190,13 @@ document.addEventListener("DOMContentLoaded", async () => {
       if (typeof collapse === 'boolean') {
         actuallyCollapsingDesktop = collapse;
       } else {
-        actuallyCollapsingDesktop = !sidebar.classList.contains("collapsed");
+        actuallyCollapsingDesktop = !sidebar.classList.contains("sidebar-is-collapsed");
       }
 
       if (!isInitialLoad) console.log(`[SIDEBAR_DESKTOP] Toggling main sidebar. Collapsing: ${actuallyCollapsingDesktop}`);
 
-      sidebar.classList.toggle("collapsed", actuallyCollapsingDesktop);
-      containerDiv.classList.toggle("sidebar-collapsed", actuallyCollapsingDesktop);
+      sidebar.classList.toggle("sidebar-is-collapsed", actuallyCollapsingDesktop);
+      containerDiv.classList.toggle("sidebar-is-collapsed", actuallyCollapsingDesktop);
       if (resizer) resizer.style.display = actuallyCollapsingDesktop ? "none" : "flex";
 
       localStorage.setItem("sidebarCollapsed", actuallyCollapsingDesktop ? "true" : "false");
@@ -1849,7 +1849,7 @@ function hideLoading() {
       nodeDisplayElement.textContent = node.name.replace(/\.json$/i, "");
 
       if (node.type === "dir") {
-        li.classList.add("folder", "collapsed");
+        li.classList.add("folder", "node-is-collapsed");
         nodeDisplayElement.title = `Folder: ${node.name}`;
         nodeDisplayElement.addEventListener("click", (e) => {
           // Allow click on text to expand/collapse only if not clicking a button inside
@@ -1857,7 +1857,7 @@ function hideLoading() {
             e.target === nodeDisplayElement ||
             e.target.classList.contains("node-text")
           ) {
-            li.classList.toggle("collapsed");
+            li.classList.toggle("node-is-collapsed");
           }
         });
         nodeContentWrapper.style.cursor = "pointer";
@@ -2316,7 +2316,7 @@ document.title = `${currentJsonData?.name || "Entry"} - Globeseekers`; // Update
         );
 
         // E. Automatic Main Sidebar Collapse on File Open (Desktop only for this behavior)
-        if (window.innerWidth > MOBILE_BREAKPOINT && sidebar && !sidebar.classList.contains('collapsed') && !sidebar.classList.contains('mobile-collapsed')) {
+        if (window.innerWidth > MOBILE_BREAKPOINT && sidebar && !sidebar.classList.contains('sidebar-is-collapsed') && !sidebar.classList.contains('mobile-collapsed')) {
             console.log("[AUTO-COLLAPSE] File opened on desktop, collapsing main sidebar.");
             toggleMainSidebar(true); // Explicitly collapse
         }
@@ -2330,7 +2330,7 @@ document.title = `${currentJsonData?.name || "Entry"} - Globeseekers`; // Update
           // Expand parent folders
           let parentLi = linkElement.closest("li.folder");
           while (parentLi) {
-            parentLi.classList.remove("collapsed");
+            parentLi.classList.remove("node-is-collapsed");
             const grandParentUl = parentLi.parentElement;
             if (grandParentUl && grandParentUl.id !== "fileTreeRoot") {
               parentLi = grandParentUl.closest("li.folder");
@@ -3833,7 +3833,7 @@ document.title = `${currentJsonData?.name || "Entry"} - Globeseekers`; // Update
         nodeContent.appendChild(label);
         li.appendChild(nodeContent);
       } else {
-        li.classList.add("collapsed");
+        li.classList.add("node-is-collapsed");
         checkbox.addEventListener("change", (e) => {
           const isChecked = e.target.checked;
           const childCheckboxes = li.querySelectorAll(
@@ -3846,7 +3846,7 @@ document.title = `${currentJsonData?.name || "Entry"} - Globeseekers`; // Update
         nodeContent.appendChild(label);
         nodeContent.addEventListener("click", (e) => {
           if (e.target !== checkbox) {
-            li.classList.toggle("collapsed");
+            li.classList.toggle("node-is-collapsed");
           }
         });
         li.appendChild(nodeContent);
@@ -4823,7 +4823,7 @@ document.title = `${currentJsonData?.name || "Entry"} - Globeseekers`; // Update
         label.textContent = displayName;
         label.title = `Item: ${node.path}`;
         if (node.type === "dir") {
-          li.classList.add("collapsed");
+          li.classList.add("node-is-collapsed");
           checkbox.addEventListener("change", (e) => {
             const isChecked = e.target.checked;
             const childCheckboxes = li.querySelectorAll(
@@ -4835,7 +4835,7 @@ document.title = `${currentJsonData?.name || "Entry"} - Globeseekers`; // Update
           nodeContent.appendChild(label);
           nodeContent.addEventListener("click", (e) => {
             if (e.target !== checkbox) {
-              li.classList.toggle("collapsed");
+              li.classList.toggle("node-is-collapsed");
             }
           });
           li.appendChild(nodeContent);

--- a/style.css
+++ b/style.css
@@ -408,7 +408,7 @@ img {
   color: #000000; /* BW */
 }
 
-#fileTreeRoot li.collapsed > ul {
+#fileTreeRoot li.node-is-collapsed > ul {
   display: none;
 }
 
@@ -423,11 +423,11 @@ img {
   color: #555555; /* BW */
 }
 
-#fileTreeRoot li.folder.collapsed > .node-content::before {
+#fileTreeRoot li.folder.node-is-collapsed > .node-content::before {
   content: "+";
 }
 
-#fileTreeRoot li.folder:not(.collapsed) > .node-content::before {
+#fileTreeRoot li.folder:not(.node-is-collapsed) > .node-content::before {
   content: "-";
 }
 
@@ -869,7 +869,7 @@ img {
   cursor: pointer;
 }
 
-.context-tree li.collapsed > ul {
+.context-tree li.node-is-collapsed > ul {
   display: none;
 }
 
@@ -886,7 +886,7 @@ img {
   font-size: 1.1em;
 }
 
-.context-tree li.folder:not(.collapsed) > .context-node-content::before {
+.context-tree li.folder:not(.node-is-collapsed) > .context-node-content::before {
   content: "-";
 }
 
@@ -1344,12 +1344,12 @@ img {
 }
 
 /* Adjustments when main sidebar is collapsed */
-.container.sidebar-collapsed .resizer {
+.container.sidebar-is-collapsed .resizer {
     display: none !important;
 }
 
 /* Alternative specific resizer hiding if not using global container class */
-/* #sidebar.collapsed + .resizer {
+/* #sidebar.sidebar-is-collapsed + .resizer {
     display: none !important;
 } */
 
@@ -1367,7 +1367,7 @@ img {
 /* For the main sidebar (#sidebar, which has class .sidebar) */
 /* Children of a collapsed sidebar should be hidden by the parent's overflow: hidden and zero dimensions. */
 /* Remove explicit visibility/opacity rules on children like nav. */
-.sidebar.collapsed > nav {
+.sidebar.sidebar-is-collapsed > nav {
     /* visibility: hidden !important; /* REMOVED */
     /* opacity: 0 !important; /* REMOVED */
     /* pointer-events: none !important; /* REMOVED */
@@ -1377,7 +1377,7 @@ img {
 /* This rule ensures that when #sidebar specifically is collapsed, */
 /* it correctly applies the zero-dimension and overflow properties. */
 /* It overrides any broader .sidebar styles that might conflict. */
-#sidebar.collapsed {
+#sidebar.sidebar-is-collapsed {
     width: 0 !important;
     min-width: 0 !important;
     padding-left: 0 !important;
@@ -1389,19 +1389,19 @@ img {
     /* visibility: hidden !important; /* AVOID: Use overflow and zero dimensions instead */
 }
 
-/* Remove rules that hide children of #sidebar.collapsed using visibility/opacity */
-#sidebar.collapsed > *:not(#collapseSidebarBtn) {
+/* Remove rules that hide children of #sidebar.sidebar-is-collapsed using visibility/opacity */
+#sidebar.sidebar-is-collapsed > *:not(#collapseSidebarBtn) {
     /* visibility: hidden !important; /* REMOVED */
     /* opacity: 0 !important; /* REMOVED */
     /* pointer-events: none !important; /* REMOVED */
 }
 
 /* Ensure the collapse button itself remains visible and interactive */
-/* This rule for #collapseSidebarBtn needs to be outside of #sidebar.collapsed > * if it's to override it,
+/* This rule for #collapseSidebarBtn needs to be outside of #sidebar.sidebar-is-collapsed > * if it's to override it,
    or be more specific. The current fixed positioning might be okay.
-   The existing #sidebar.collapsed #collapseSidebarBtn rule handles this.
+   The existing #sidebar.sidebar-is-collapsed #collapseSidebarBtn rule handles this.
 */
-#sidebar.collapsed #collapseSidebarBtn {
+#sidebar.sidebar-is-collapsed #collapseSidebarBtn {
     visibility: visible !important; /* Ensure button is visible */
     opacity: 1 !important; /* Ensure button is fully opaque */
     pointer-events: auto !important; /* Ensure button is interactive */


### PR DESCRIPTION
Previously, the '.collapsed' class was used for both the main sidebar's collapsed state and for individual tree folder nodes' collapsed states. This caused an issue where collapsing the sidebar would also collapse all expanded tree nodes.

This commit introduces two distinct classes:
- `.sidebar-is-collapsed`: For the main sidebar's collapsed state.
- `.node-is-collapsed`: For individual tree folder nodes' collapsed state.

CSS and JavaScript files (`style.css` and `script.js`) have been updated to use these new, more specific class names in their respective contexts.

The generic '.collapsed' class remains for other elements that might use it independently (e.g., the image preview sidebar).

This change ensures that collapsing the sidebar does not affect the expanded/collapsed state of the file tree nodes, and vice-versa.