### PR TITLE
Fix: Disable sidebar auto-collapse and update mobile buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,9 +41,18 @@
     <nav id="fileTreeContainer">
         <ul id="fileTreeRoot"></ul>
     </nav>
-    <button id="createNewFileBtn" style="margin-top: 15px;" disabled>Create New Entry (Root)</button>
-    <button id="createNewFolderBtn" style="margin-top: 10px;" disabled>Create New Folder (Root)</button>
-    <button id="reorganizeEntriesBtn" style="margin-top: 10px;" disabled>Reorganize Entries</button>
+    <button id="createNewFileBtn" style="margin-top: 15px;" disabled>
+      <span class="button-icon">+</span>
+      <span class="button-text">Create New Entry (Root)</span>
+    </button>
+    <button id="createNewFolderBtn" style="margin-top: 10px;" disabled>
+      <span class="button-icon">📁</span>
+      <span class="button-text">Create New Folder (Root)</span>
+    </button>
+    <button id="reorganizeEntriesBtn" style="margin-top: 10px;" disabled>
+      <span class="button-icon">⇆</span>
+      <span class="button-text">Reorganize Entries</span>
+    </button>
     <button id="collapseSidebarBtn" style="margin-top: 10px;">«</button>
 </aside>
 

--- a/script.js
+++ b/script.js
@@ -2316,10 +2316,10 @@ document.title = `${currentJsonData?.name || "Entry"} - Globeseekers`; // Update
         );
 
         // E. Automatic Main Sidebar Collapse on File Open (Desktop only for this behavior)
-        if (window.innerWidth > MOBILE_BREAKPOINT && sidebar && !sidebar.classList.contains('sidebar-is-collapsed') && !sidebar.classList.contains('mobile-collapsed')) {
-            console.log("[AUTO-COLLAPSE] File opened on desktop, collapsing main sidebar.");
-            toggleMainSidebar(true); // Explicitly collapse
-        }
+        // if (window.innerWidth > MOBILE_BREAKPOINT && sidebar && !sidebar.classList.contains('sidebar-is-collapsed') && !sidebar.classList.contains('mobile-collapsed')) {
+        //     console.log("[AUTO-COLLAPSE] File opened on desktop, collapsing main sidebar.");
+        //     toggleMainSidebar(true); // Explicitly collapse
+        // }
 
         if (activeLinkElement && activeLinkElement !== linkElement) {
           activeLinkElement.classList.remove("active");

--- a/style.css
+++ b/style.css
@@ -1058,9 +1058,41 @@ img {
         border-bottom: 2px solid #bbbbbb; /* BW */
     }
     .sidebar #createNewFileBtn, .sidebar #createNewFolderBtn, .sidebar #reorganizeEntriesBtn {
-        padding: 10px 12px; /* Easier to tap */
+        /* Default mobile padding and font-size, will be overridden by more specific icon-only styles below */
+        padding: 10px 12px; 
         font-size: 0.95em;
     }
+
+  /* Mobile styles for sidebar buttons - Icon only */
+  .sidebar #createNewFileBtn,
+  .sidebar #createNewFolderBtn,
+  .sidebar #reorganizeEntriesBtn {
+    padding: 8px; /* Adjust padding to make buttons smaller for icon */
+    text-align: center;
+    display: flex; 
+    align-items: center;
+    justify-content: center;
+    line-height: 1; 
+  }
+
+  .sidebar .button-icon {
+    display: inline; /* Show the icon */
+    font-size: 1.2em; /* Make icon slightly larger than text */
+    margin-right: 0; /* No margin as text will be hidden */
+  }
+
+  .sidebar .button-text {
+    display: none; /* Hide the text on mobile */
+  }
+  /* Optional: Adjust button width if they are full width by default and become too wide */
+  /*
+  .sidebar #createNewFileBtn,
+  .sidebar #createNewFolderBtn,
+  .sidebar #reorganizeEntriesBtn {
+    width: auto; /* Allow button to shrink to icon size + padding */
+    min-width: 40px; /* Example minimum width */
+  }
+  */
 
     .resizer {
         display: none;


### PR DESCRIPTION
- I disabled the automatic collapse of the sidebar when you open an article on desktop view by commenting out the relevant JavaScript code.
- I redesigned sidebar buttons ('Create New Entry (Root)', 'Create New Folder (Root)', 'Reorganize Entries') for mobile view:
    - Buttons now display as small, icon-only buttons on screens <= 768px wide.
    - I used text-based icons (+, 📁, ⇆) as placeholders.
    - I updated the HTML to include spans for icons and text.
    - I added CSS to handle the mobile-specific styling.