### PR TITLE
Fix: Remove immediate API key prompt at startup

### DIFF
--- a/script.js
+++ b/script.js
@@ -701,9 +701,12 @@ document.addEventListener("DOMContentLoaded", async () => {
                 console.log("[INIT] Proceeding with app initialization as a GitHub token is available.");
                 await proceedWithAppInitialization(true); // true for initial load
             } else {
-                // This block is now ONLY reached if NEITHER GITHUB_READ_TOKEN from config NOR GITHUB_WRITE_TOKEN from session was found.
-                console.log("[INIT] No GitHub token available from config or session. Prompting for a token via modal.");
-                showApiKeyModal(true, false, "general");
+                console.log("[INIT] No GitHub token available from config or session. App will attempt to load. Data fetching will likely fail if no token is subsequently provided, and an error message will be shown then. User can add tokens manually via 'Add/Edit Tokens' button or will be prompted by specific actions if tokens are required.");
+                // Attempt to proceed. `fetchFileList` (called within `proceedWithAppInitialization`)
+                // will use `getGitHubHeaders()`. If no token is available, `getGitHubHeaders`
+                // for a read operation will throw an error.
+                // This error is caught by `fetchFileList` and displayed to the user via `showError()`.
+                await proceedWithAppInitialization(true);
             }
 
         } catch (error) {


### PR DESCRIPTION
This commit modifies the application's initialization behavior regarding API token handling.

- The application will no longer immediately prompt for GitHub or Gemini API keys when it opens, even if no tokens are found in the configuration or session storage.
- It will attempt to initialize, and if data fetching (e.g., loading the file list) fails due to missing tokens, an error message will be displayed to you at that point. You can then use the 'Add/Edit Tokens' button or be prompted by specific actions that require tokens.
- The existing behavior of using the read-only API token from `config.json` by default for read operations, if an editable (write) token is not present in the session, has been verified and maintained.

This change addresses the issue where you were immediately prompted for tokens upon opening the application, improving the initial user experience, especially when a read-only token is configured or when you intend to manually input tokens later.