### PR TITLE
Fix: Ensure DEFAULT_READ_TOKEN_PARTS from config.json is used

### DIFF
--- a/script.js
+++ b/script.js
@@ -800,6 +800,20 @@ document.addEventListener("DOMContentLoaded", async () => {
         throw new Error("config.json is missing required top-level keys.");
       console.log("[CONFIG] config.json loaded successfully.");
 
+      // *** NEW LOGIC TO ASSEMBLE TOKEN ***
+      if (appConfig.github && appConfig.github.DEFAULT_READ_TOKEN_PARTS && Array.isArray(appConfig.github.DEFAULT_READ_TOKEN_PARTS)) {
+        appConfig.github.TOKEN = appConfig.github.DEFAULT_READ_TOKEN_PARTS.join('');
+        console.log("[CONFIG] Assembled GitHub Read Token from DEFAULT_READ_TOKEN_PARTS.");
+      } else {
+        console.log("[CONFIG] DEFAULT_READ_TOKEN_PARTS not found or not an array in config.json. `appConfig.github.TOKEN` will rely on direct value if set, or be undefined.");
+        // Ensure appConfig.github.TOKEN is not undefined if DEFAULT_READ_TOKEN_PARTS is missing,
+        // so that later checks for appConfig.github.TOKEN don't fail unexpectedly if it was meant to be empty.
+        if (appConfig.github && typeof appConfig.github.TOKEN === 'undefined') {
+            appConfig.github.TOKEN = ""; // Initialize to empty string if not set by parts or directly
+        }
+      }
+      // *** END NEW LOGIC ***
+
       GITHUB_USERNAME = appConfig.github.USERNAME;
       GITHUB_REPO = appConfig.github.REPO;
       GITHUB_DATA_PATH = appConfig.github.DATA_PATH;


### PR DESCRIPTION
This commit addresses an issue where the `DEFAULT_READ_TOKEN_PARTS` array in `config.json` was not being correctly assembled and utilized as the default read-only GitHub token.

The `loadConfig` function in `script.js` has been modified to:
- Explicitly check for `appConfig.github.DEFAULT_READ_TOKEN_PARTS`.
- If found and is an array, join its elements to form a single token string.
- Assign this assembled token to `appConfig.github.TOKEN`.

This ensures that the `initialize` function can then correctly set the global `GITHUB_READ_TOKEN` using this assembled token.

With this change:
- If `DEFAULT_READ_TOKEN_PARTS` is properly configured in `config.json`, the application will start and operate in read-only mode using this token without prompting you for API keys at startup.
- This fixes the scenario you reported where your configured read-only token parts were not being recognized.
- The previous fix to prevent immediate token prompts if *no* tokens (neither config nor session) are available is maintained.