### PR TITLE
Fix: Improve subfolder creation functionality

### DIFF
--- a/script.js
+++ b/script.js
@@ -2014,13 +2014,11 @@ function getGitHubHeaders(forWriteOperation = false) {
           // Expand the parent folder in the tree after creation
           const parentLi = event.target.closest("li.folder");
           if (parentLi) {
-            parentLi.classList.remove("collapsed");
+            parentLi.classList.remove("node-is-collapsed");
           }
           await fetchFileList(); // Refresh the entire file list
         } else {
-          console.warn(
-            "Subfolder creation might have failed as commitResult was null."
-          );
+          alert(`Failed to create subfolder "${newSubfolderName}" on GitHub. The .gitkeep file could not be committed.`);
         }
       } catch (error) {
         console.error("Error creating subfolder:", error);


### PR DESCRIPTION
This commit addresses issues with subfolder creation:

- Ensures that an explicit alert is shown to you if the .gitkeep file commitment to GitHub fails during subfolder creation.
- Corrects the CSS class used to expand the parent folder in the file tree UI after successful subfolder creation (`node-is-collapsed` instead of `collapsed`).
- Ensures that the file list is refreshed by calling `fetchFileList()` only after a successful commit of the .gitkeep file for the new subfolder.

These changes provide better feedback and ensure the UI behaves as expected during subfolder creation.